### PR TITLE
Create backend.php

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -46,7 +46,16 @@ $wwwroot = $CFG->wwwroot;
 
 $pathendpoint = $wwwroot . "/mod/ivs/backend.php/";
 
-$httpschema = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+// $_SERVER['HTTPS'] == 'on' could be not available in all webserver versions
+if ( (! empty($_SERVER['REQUEST_SCHEME']) && $_SERVER['REQUEST_SCHEME'] == 'https') ||
+     (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ||
+     (! empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443') ) {
+    $httpschema = 'https';
+} else {
+    $httpschema = 'http';
+}
+
+
 $backendService = new \mod_ivs\BackendService();
 if (!isset($_SERVER['HTTP_HOST'])) {
     $backendService->ivs_backend_error_exit('No http host found');


### PR DESCRIPTION
$_SERVER['HTTPS'] == 'on' could be not available in all webserver versions.
We test on two more server environment variables.